### PR TITLE
Hackday: create Certificate from Username and Project URL

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -109,12 +109,13 @@
               <div class="assignment">
                   This certificate is presented to
               </div>
-              <div class="person">TODO: get the username from the API</div>
+              <div id='certificate-user' class="person">Anonymous</div>
               <div class="reason">
                   For contributing
                   <br>
-                  <div id='user-contributions' class='contributions'>0</div>
-                  hours to a project
+                  <div id='certificate-time' class='contributions'>0</div>
+                  hours to
+                  <div id='certificate-project'>a project</div>
               </div>
             </div>
           </div>

--- a/static/index.html
+++ b/static/index.html
@@ -76,7 +76,18 @@
     <body>
       <div class="flex-container">
         <div class="row">
-          <div class="flex-item">
+          <form class="flex-item" action="?" method="get">
+            <label>
+              Username
+              <input type="text" name="username" />
+            </label>
+            <label>
+              Project Slug
+              <input type="text" name="project"/>
+            </label>
+            <button >Fetch Data</button>
+          </form>
+          <div class="flex-item" style="display: none">
             <p><strong>Generate a contribution certificate for a known user ID</strong>
             <div>
               <small>User ID</small>

--- a/static/index.html
+++ b/static/index.html
@@ -82,8 +82,8 @@
               <input type="text" name="username" />
             </label>
             <label>
-              Project Slug
-              <input type="text" name="project"/>
+              Project URL
+              <input type="text" name="projectURL"/>
             </label>
             <button >Fetch Data</button>
           </form>

--- a/static/loadUserStats.js
+++ b/static/loadUserStats.js
@@ -156,8 +156,4 @@ class ZooniverseCertificateApp {
   }
 }
 
-function init () {
-  console.log('xxx')
-}
-
 window.onload = function init() { window.zooApp = new ZooniverseCertificateApp() }

--- a/static/loadUserStats.js
+++ b/static/loadUserStats.js
@@ -45,3 +45,67 @@ async function updateUserCertifcate() {
   document.getElementById('user-contributions').textContent = userContributionsInHours
 
 }
+
+const PANOPTES_OPTIONS = {
+  headers: {
+    'accept': 'application/vnd.api+json; version=1',
+    'content-type': 'application/json'
+  }
+}
+
+class ZooniverseCertificateApp {
+  constructor () {
+    //
+    this.input = {
+      username: null,
+      project: null
+    }
+
+    this.data = {
+      user: undefined,
+    }
+
+    this.getInput()
+
+    console.log('+++ this.input ', this.input)
+    this.fetchUserData(this.input.username)
+  }
+
+  /*
+  Gets and saves user input.
+   */
+  getInput () {
+    try {
+      const params = (new URL(window.location)).searchParams
+      this.input.username = params.get('username')
+      this.input.project = params.get('project')
+      // Note: returns null if query param doesn't exist
+    } catch (err) {
+      this.handleError(err)
+    }
+  }
+
+  async fetchUserData (username) {
+    const _username = encodeURIComponent((username || '').trim())
+    if (!_username) return
+    const response = await fetch(`https://www.zooniverse.org/api/users?http_cache=true&login=${_username}`, PANOPTES_OPTIONS)
+    if (response.ok) {
+      const data = await response.json()
+      this.data.user = data?.users?.[0]
+      console.log('+++ user: ', this.data.user)
+      // TODO: set status
+    } else {
+      // TODO: error
+    }
+  }
+
+  handleError (err) {
+    console.error(err)
+  }
+}
+
+function init () {
+  console.log('xxx')
+}
+
+window.onload = function init() { window.zooApp = new ZooniverseCertificateApp() }

--- a/static/loadUserStats.js
+++ b/static/loadUserStats.js
@@ -36,6 +36,8 @@ async function loadUserContributionsInSeconds(userId, workflowId) {
   return userContributionsInSeconds;
 }
 
+/*
+TODO: remove
 async function updateUserCertifcate() {
   userId = document.getElementById("userId").value;
   workflowId = document.getElementById("workflowId").value;
@@ -43,8 +45,8 @@ async function updateUserCertifcate() {
   let userContributionsInHours = userContributionsInSeconds / (60.0 * 60.0)
   userContributionsInHours = userContributionsInHours.toFixed(4)
   document.getElementById('user-contributions').textContent = userContributionsInHours
-
 }
+*/
 
 const PANOPTES_OPTIONS = {
   headers: {
@@ -68,9 +70,9 @@ class ZooniverseCertificateApp {
 
     this.getInput()
 
-    console.log('+++ this.input ', this.input)
-    this.fetchUserData(this.input.username)
-    this.fetchProjectData(this.input.projectURL)
+    if (this.input.username && this.input.projectURL) {
+      this.fetchData()
+    }
   }
 
   /*
@@ -88,6 +90,31 @@ class ZooniverseCertificateApp {
       document.getElementsByName('projectURL')[0].value = this.input.projectURL
     } catch (err) {
       this.handleError(err)
+    }
+  }
+
+  async fetchData () {
+    await this.fetchUserData(this.input.username)
+    await this.fetchProjectData(this.input.projectURL)
+
+    try {
+      const user = this.data.user
+      const project = this.data.project
+      if (!user || !project) throw new Error()
+
+      const workflows = project?.links?.active_workflows || []
+
+      let totalTime = 0
+      for (let i = 0; i < workflows.length; i++) {
+        const wfID = workflows[i]
+        const wfTime = await loadUserContributionsInSeconds(user.id, wfID)
+        totalTime += wfTime || 0
+      }
+
+      console.log('totalTime: ', totalTime)
+
+    } catch (err) {
+      // TODO
     }
   }
 
@@ -116,6 +143,9 @@ class ZooniverseCertificateApp {
       this.data.project = data?.projects?.[0]
       console.log('+++ project', this.data.project)
       // TODO: set status
+
+      const workflows = this.data.project?.links?.active_workflows || []
+
     } else {
       // TODO: error
     }

--- a/static/loadUserStats.js
+++ b/static/loadUserStats.js
@@ -75,6 +75,15 @@ class ZooniverseCertificateApp {
     }
   }
 
+  updateCertificate (userName = '???', projectName = '???', timeInSeconds = 0) {
+    let userContributionsInHours = timeInSeconds / (60 * 60)
+    userContributionsInHours = userContributionsInHours.toFixed(4)
+
+    document.getElementById('certificate-user').textContent = userName
+    document.getElementById('certificate-project').textContent = projectName
+    document.getElementById('certificate-time').textContent = userContributionsInHours
+  }
+
   /*
   Gets and saves user input.
    */
@@ -104,14 +113,18 @@ class ZooniverseCertificateApp {
 
       const workflows = project?.links?.active_workflows || []
 
-      let totalTime = 0
+      let contributedTimeInSeconds = 0
       for (let i = 0; i < workflows.length; i++) {
         const wfID = workflows[i]
         const wfTime = await loadUserContributionsInSeconds(user.id, wfID)
-        totalTime += wfTime || 0
+        contributedTimeInSeconds += wfTime || 0
       }
 
-      console.log('totalTime: ', totalTime)
+      this.updateCertificate(
+        user.display_name?.trim() || user.login,
+        project.display_name,
+        contributedTimeInSeconds
+      )
 
     } catch (err) {
       // TODO

--- a/static/loadUserStats.js
+++ b/static/loadUserStats.js
@@ -58,7 +58,7 @@ class ZooniverseCertificateApp {
     //
     this.input = {
       username: null,
-      project: null
+      projectURL: null
     }
 
     this.data = {
@@ -69,6 +69,7 @@ class ZooniverseCertificateApp {
 
     console.log('+++ this.input ', this.input)
     this.fetchUserData(this.input.username)
+    this.fetchProjectData(this.input.projectURL)
   }
 
   /*
@@ -78,8 +79,12 @@ class ZooniverseCertificateApp {
     try {
       const params = (new URL(window.location)).searchParams
       this.input.username = params.get('username')
-      this.input.project = params.get('project')
+      this.input.projectURL = params.get('projectURL')
       // Note: returns null if query param doesn't exist
+
+      // Sync the UI with the input
+      document.getElementsByName('username')[0].value = this.input.username
+      document.getElementsByName('projectURL')[0].value = this.input.projectURL
     } catch (err) {
       this.handleError(err)
     }
@@ -97,6 +102,15 @@ class ZooniverseCertificateApp {
     } else {
       // TODO: error
     }
+  }
+
+  async fetchProjectData (projectURL) {
+    const projectRegex = /zooniverse.org\/projects\/([^\/]*\/[^\/]*)/i
+    // const matches = projectURL.match(projectRegex)
+    const projectSlug = projectURL.match(projectRegex)?.[1]
+
+    console.log('+++ projectSlug: ', projectSlug)
+
   }
 
   handleError (err) {

--- a/static/loadUserStats.js
+++ b/static/loadUserStats.js
@@ -63,6 +63,7 @@ class ZooniverseCertificateApp {
 
     this.data = {
       user: undefined,
+      project: undefined,
     }
 
     this.getInput()
@@ -106,11 +107,18 @@ class ZooniverseCertificateApp {
 
   async fetchProjectData (projectURL) {
     const projectRegex = /zooniverse.org\/projects\/([^\/]*\/[^\/]*)/i
-    // const matches = projectURL.match(projectRegex)
     const projectSlug = projectURL.match(projectRegex)?.[1]
+    const _projectSlug = encodeURIComponent((projectSlug || '').trim())
 
-    console.log('+++ projectSlug: ', projectSlug)
-
+    const response = await fetch(`https://www.zooniverse.org/api/projects?http_cache=true&slug=${_projectSlug}`, PANOPTES_OPTIONS)
+    if (response.ok) {
+      const data = await response.json()
+      this.data.project = data?.projects?.[0]
+      console.log('+++ project', this.data.project)
+      // TODO: set status
+    } else {
+      // TODO: error
+    }
   }
 
   handleError (err) {


### PR DESCRIPTION
## PR Overview

Part of: Hackday Sep 2022 and Hackday Oct 2022

This PR updates the certificate to be slightly more user-friendly: users can now provide their **login username** (instead of the numerical _user ID_) and **project URL** (instead of the _project ID_) to generate their Volunteer Certificate.

_Example: certificate generated with input `darkeshard` and `https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess`_
<img width="782" alt="Screenshot 2022-10-12 at 15 39 33" src="https://user-images.githubusercontent.com/13952701/195375145-aae27e21-4125-4dfb-bafc-3bec1a2fa261.png">

- UI changes:
  - "user id" input changed to "username"
  - "project id" input changed to "project URL".
  - Certificate now shows the project's name.
- Functionality Changes:
  - The "total contributed time" now calculates the time the user contributed **across all active workflows** for the project, not just a single workflow. (❓ This might need to be changed to _all workflows, active or otherwise._ ) 
  - For ease of sharing, the URL now accepts `?username` and `?projectURL` as query parameters.

Missing features:
- Any sort of loading/fetching progress status
- Any sort of error handling
- Any sort of fallback for 1. invalid usernames, 2. invalid projects, 3. projects that aren't in the database(???)
- Any sort of accessible design for the cert. (In general, the visually rendered cert will be the work of another hackday)

### Dev Notes

- I packaged all the new code into the `ZooniverseCertificateApp` class, but didn't touch the old code as much as I could. I wanted to keep optimisations/refactors/ _"changing the code to look the way I like it"_ separate from the functionality added in this PR
- I briefly made the form input ask for _project slug,_ but I realise not all volunteers might understand what constitutes a slug. Hence, the URL seems far easier for a standard volunteer to copy-and-paste.
  - Possibly an even better way of doing this is to automatically list all projects that a user has contributed to.
  - 🐛 Bug: the regex doesn't handle `zooniverse.org/projects/darkeshard/test-project-2022?env=staging`, as the `?env=` is bunched together into the project slug. Derp! 
- ❓ The "total contributed time" should probably calculate ALL the workflows the user has contributed to, whether that WF is active or not. This is because many projects deactivate workflows after they're complete, meaning in an extreme-case scenario, a volunteer might see they've contributed 0 hours to a project when in fact they've managed to single-handedly bring several workflows to 100% completion.

### Status

Ready for testing & review!

Testers, please note that we don't have a staging environment for this yet, so you've got to download the repo then run `docker-compose build` / `docker-compose up` then test on `localhost:8000`